### PR TITLE
Remove runFullTrust capability

### DIFF
--- a/ToastNotifierPkg/Package.appxmanifest
+++ b/ToastNotifierPkg/Package.appxmanifest
@@ -48,7 +48,6 @@
   </Applications>
 
   <Capabilities>
-    <rescap:Capability Name="runFullTrust" />
     <uap3:Capability Name="userNotificationListener"/>
   </Capabilities>
 </Package>


### PR DESCRIPTION
This unfortunately doesn't seem to make any difference. The deployed MSIX still run under medium IL.


### Testing of release MSIX on clean Win11 computer
Startup error:
![image](https://user-images.githubusercontent.com/2671400/168497659-90bb82d5-f007-4701-bc68-d7f030f926bc.png)
Events are generated, but callbacks are not received:
![image](https://user-images.githubusercontent.com/2671400/168497742-1e13e80c-6f21-45ce-8026-51915832f7ea.png)

None of these problems seem to be regressions though, since they both also occur when building master.