### PR TITLE
Run ToastNotifier to AppContainer

### DIFF
--- a/ToastNotifierPkg/Package.appxmanifest
+++ b/ToastNotifierPkg/Package.appxmanifest
@@ -33,7 +33,7 @@
   <Applications>
     <Application Id="App"
       Executable="$targetnametoken$.exe"
-      EntryPoint="$targetentrypoint$">
+      EntryPoint="Windows.PartialTrustApplication">
       <uap:VisualElements
         DisplayName="ToastNotifier Packaged"
         Description="ToastNotifier"


### PR DESCRIPTION
Based on suggestion on https://github.com/microsoft/WindowsAppSDK/issues/219

Leads to the following error:
```
1>MakeAppx : error : Error info: error 80080204: App manifest validation error: Line 31, Column 24, Reason: The "windows.aboveLockScreen" Extension can't be declared with Partial Trust EntryPoint.
1>MakeAppx : error : Package creation failed.
1>MakeAppx : error : 0x80080204 - The specified package format is not valid: The package manifest is not valid.
```

This works in the sense that the app now runs in an AppContainer. However, the same #1 deployment problem still persist. Also, I had to remove `windows.aboveLockScreen` to get the packaging to succeed.

![image](https://user-images.githubusercontent.com/2671400/168557286-8254b514-a11b-4508-adfb-7946a1b9e354.png)

Capabilities:
```
internetClient: S-1-15-3-1 (APPLICATION PACKAGE AUTHORITY\Your Internet connection)
userNotificationListener: S-1-15-3-1024-1195710214-366596411-2746218756-3015581611-3786706469-3006247016-1014575659-1338484819
runFullTrust: S-1-15-3-1024-1365790099-2797813016-1714917928-519942599-2377126242-1094757716-3949770552-3596009590
S-1-15-3-1024-2732930991-1716039000-1394599507-3926803129-3068501044-2027633224-866606239-446136062	Capability
S-1-15-3-1024-982116356-1157887588-2052581112-4048931602-275598005-2450320559-1358259137-3354152412	Capability
S-1-15-3-1376231032-1094691115-4276622258-1915646261	Capability
S-1-15-3-1969208800-225334143-3501817099-697135235-2288452206-1962081413-4047152401	Capability
```