### PR TITLE
Add ProcessorArchitecture="x64" to the package identity.

### DIFF
--- a/ToastNotifier/Package.appxmanifest
+++ b/ToastNotifier/Package.appxmanifest
@@ -9,6 +9,7 @@
 
   <Identity
     Name="c726ae17-29df-476b-b51b-ec6def2cb9cf"
+    ProcessorArchitecture="x64"
     Publisher="CN=forderud"
     Version="1.0.0.0" />
 


### PR DESCRIPTION
This unfortunately doesn't seem to make any difference when deploying to a target machine.